### PR TITLE
Add support for XLP family: mx274 and others.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,13 @@ config.guess
 config.sub
 install-sh
 missing
-
+*.o
+Makefile
+config.h
+config.h.in~
+config.log
+config.status
+src/Makefile
+src/families/.dirstamp
+src/pic32prog
+stamp-h1

--- a/src/adapters/adapter-pickit2.c
+++ b/src/adapters/adapter-pickit2.c
@@ -137,7 +137,7 @@ static void serial_execution(pickit_adapter_t *a)
     // Enter serial execution.
     if (debug_level > 0)
         fprintf(stderr, "%s: enter serial execution\n", a->name);
-    pickit_send(a, 29, CMD_EXECUTE_SCRIPT, 27,
+    pickit_send(a, 31, CMD_EXECUTE_SCRIPT, 29,
         SCRIPT_JT2_SENDCMD, TAP_SW_MTAP,
         SCRIPT_JT2_SENDCMD, MTAP_COMMAND,
         SCRIPT_JT2_XFERDATA8_LIT, MCHP_STATUS,
@@ -150,6 +150,7 @@ static void serial_execution(pickit_adapter_t *a)
         SCRIPT_JT2_SENDCMD, TAP_SW_MTAP,
         SCRIPT_JT2_SENDCMD, MTAP_COMMAND,
         SCRIPT_JT2_XFERDATA8_LIT, MCHP_DEASSERT_RST,
+        SCRIPT_DELAY_LONG, 20, // 100 msec
         SCRIPT_JT2_XFERDATA8_LIT, MCHP_FLASH_ENABLE);
 }
 

--- a/src/families/family-mx1.c
+++ b/src/families/family-mx1.c
@@ -336,13 +336,13 @@ void print_mx1(unsigned cfg0, unsigned cfg1, unsigned cfg2, unsigned cfg3)
         printf("              %u        Peripheral Module Disable - only 1 reconfig\n",
             MX1_CFG3_PMDL1WAY >> 28);
     else
-        printf("                       USBID pin: controlled by port\n");
+        printf("                       Peripheral Module Disable - allow multiple reconfigurations\n");
 
     if (cfg3 & MX1_CFG3_IOL1WAY)
         printf("              %u        Peripheral Pin Select - only 1 reconfig\n",
             MX1_CFG3_IOL1WAY >> 28);
     else
-        printf("                       USBID pin: controlled by port\n");
+        printf("                       Peripheral Pin Select - allow multiple reconfigurations\n");
 
     if (cfg3 & MX1_CFG3_FUSBIDIO)
         printf("              %u        USBID pin: controlled by USB\n",

--- a/src/target.c
+++ b/src/target.c
@@ -38,6 +38,9 @@ static const
 family_t family_mx1 = { "mx1",
                         3,  0x0bf0, 128,  print_mx1, pic32_pemx1, 422,  0x0301 };
 static const
+family_t family_xlp = { "xlp",
+                        12, 0x2ff0, 512,  print_mx1, pic32_pemx3, 1044, 0x0201 };
+static const
 family_t family_mx3 = { "mx3",
                         12, 0x2ff0, 512,  print_mx3, pic32_pemx3, 1044, 0x0201 };
 static const
@@ -108,6 +111,24 @@ static variant_t pic32_tab[TABSZ] = {
     {0x6A15053, "MX550F256L",    256,   &family_mx1},
     {0x6A34053, "MX570F512H",    512,   &family_mx1},
     {0x6A35053, "MX570F512L",    512,   &family_mx1},
+
+    /* XLP Family---------------Flash---Family */
+    {0x7800053, "MX154F128B",    128,   &family_xlp},
+    {0x7804053, "MX154F128D",    128,   &family_xlp},
+    {0x7808053, "MX155F128B",    128,   &family_xlp},
+    {0x780C053, "MX155F128D",    128,   &family_xlp},
+    {0x7801053, "MX174F256B",    256,   &family_xlp},
+    {0x7805053, "MX174F256D",    256,   &family_xlp},
+    {0x7809053, "MX175F256B",    256,   &family_xlp},
+    {0x780D053, "MX175F256D",    256,   &family_xlp},
+    {0x7802053, "MX254F128B",    128,   &family_xlp},
+    {0x7806053, "MX254F128D",    128,   &family_xlp},
+    {0x780A053, "MX255F128B",    128,   &family_xlp},
+    {0x780E053, "MX255F128D",    128,   &family_xlp},
+    {0x7803053, "MX274F256B",    256,   &family_xlp},
+    {0x7807053, "MX274F256D",    256,   &family_xlp},
+    {0x780B053, "MX275F256B",    256,   &family_xlp},
+    {0x780F053, "MX275F256D",    256,   &family_xlp},
 
     /* MX3/4/5/6/7 family-------Flash---Family */
     {0x0902053, "MX320F032H",     32,   &family_mx3},


### PR DESCRIPTION
With this change, pic32prog is able to program pic32mx274 chip and others from XLP family.
